### PR TITLE
Quick readme example update based on end-to-end-concourse-ci repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ configuration:
 
 ```hcl-terraform
 module "acm_certificate" {
-  source = "infrablocks/acm-certificate/aws"
-  version = "0.0.1"
+  source  = "infrablocks/acm-certificate/aws"
+  version = "1.0.0"
+
+  domain_name = "*.${data.terraform_remote_state.domain.outputs.domain_name}"
+  domain_zone_id = data.terraform_remote_state.domain.outputs.public_zone_id
+
+  subject_alternative_names = []
+  subject_alternative_name_zone_id = data.terraform_remote_state.domain.outputs.public_zone_id
+
+  providers = {
+    aws.certificate = aws
+    aws.domain_validation = aws
+    aws.san_validation = aws
+  }
 }
 ```
 


### PR DESCRIPTION
Hello, 

I was struggling to get this module working until I found the https://github.com/infrablocks/end-to-end-concourse-ci repo, as such I thought it would be useful to have the example from that in the readme, since the current readme example complains about missing providers.

Thanks,
Jordan